### PR TITLE
Walidator PESEL

### DIFF
--- a/src/main/java/org/example/VerificationPESEL.java
+++ b/src/main/java/org/example/VerificationPESEL.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class VerificationPESEL {
+    public static boolean checkNumberOfDigitsInPESEL(String pesel) {
+        Pattern pattern = Pattern.compile("\\d{11}");
+        Matcher matcher = pattern.matcher(pesel);
+        return matcher.matches();
+    }
+
+}

--- a/src/test/java/org/example/VerificationPESELTest.java
+++ b/src/test/java/org/example/VerificationPESELTest.java
@@ -1,0 +1,61 @@
+package org.example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VerificationPESELTest {
+
+    @Test
+    void checkNumberOfDigitsInPESEL() {
+        //given
+        String pesel = "12345678912";
+        boolean excepted = true;
+
+        //when
+        boolean result = VerificationPESEL.checkNumberOfDigitsInPESEL(pesel);
+
+        //then
+        Assertions.assertEquals(excepted, result);
+    }
+
+    @Test
+    void checkNumberOfDigitsInPESEL_whenWrongNumberOfDigits() {
+        //given
+        String pesel = "1234567891234567";
+        boolean excepted = false;
+
+        //when
+        boolean result = VerificationPESEL.checkNumberOfDigitsInPESEL(pesel);
+
+        //then
+        Assertions.assertEquals(excepted, result);
+    }
+
+    @Test
+    void checkNumberOfDigitsInPESEL_whenThereAreLetters() {
+        //given
+        String pesel = "1a345678912";
+        boolean excepted = false;
+
+        //when
+        boolean result = VerificationPESEL.checkNumberOfDigitsInPESEL(pesel);
+
+        //then
+        Assertions.assertEquals(excepted, result);
+    }
+
+    @Test
+    void checkNumberOfDigitsInPESEL_whenThereAreOtherSymbols() {
+        //given
+        String pesel = "1 345678912";
+        boolean excepted = false;
+
+        //when
+        boolean result = VerificationPESEL.checkNumberOfDigitsInPESEL(pesel);
+
+        //then
+        Assertions.assertEquals(excepted, result);
+    }
+}


### PR DESCRIPTION
Napisz walidator (wyrażenie regularne), którego celem będzie walidacja numeru PESEL. Walidacja powinna uwzględniać :
●      ilość znaków
●      sprawdzenie, czy PESEL składa się tylko z cyfr