### PR TITLE
Wybieranie liczb

### DIFF
--- a/src/main/java/org/example/SelectingNumbers.java
+++ b/src/main/java/org/example/SelectingNumbers.java
@@ -1,0 +1,32 @@
+package org.example;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SelectingNumbers {
+
+    public static void selectionIntegersFromText(String text) {
+        Pattern pattern = Pattern.compile("(?:\\s|^)\\d+(?=\\s|$)");
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            System.out.println(matcher.group());
+        }
+    }
+
+    public static void selectionDoublesFromText(String text) {
+        Pattern pattern = Pattern.compile("\\b\\d\\.\\d+\\b");
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            System.out.println(matcher.group());
+        }
+    }
+
+    public static void selectionNumbersInExponentialNotationFromText(String text) {
+        Pattern pattern = Pattern.compile("\\b\\d\\.\\d+[a-zA-Z]\\+?\\-?\\d{2}\\b");
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            System.out.println(matcher.group());
+        }
+    }
+
+}

--- a/src/test/java/org/example/SelectingNumbersTest.java
+++ b/src/test/java/org/example/SelectingNumbersTest.java
@@ -1,0 +1,48 @@
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class SelectingNumbersTest {
+
+    @Test
+    void mustSelectionIntegersFromText() {
+        //given
+        String text = "342\n5.34\n756\n1.234e+07\n7.234243E-02\n6.09\n3457\n87\n1.0001\n3\n5";
+        String excepted = "342\n756\n3457\n87\n3\n5";
+
+        //when
+        System.out.println(excepted);
+        System.out.println();
+
+        //then
+        SelectingNumbers.selectionIntegersFromText(text);
+    }
+
+    @Test
+    void mustSelectionDoublesFromText() {
+        //given
+        String text = "342\n5.34\n756\n1.234e+07\n7.234243E-02\n6.09\n3457\n87\n1.0001\n3\n5";
+        String excepted = "5.34\n6.09\n1.0001";
+
+        //when
+        System.out.println(excepted);
+        System.out.println();
+
+        //then
+        SelectingNumbers.selectionDoublesFromText(text);
+    }
+
+    @Test
+    void mustSelectionNumbersInExponentialNotationFromText() {
+        //given
+        String text = "342\n5.34\n756\n1.234e+07\n7.234243E-02\n6.09\n3457\n87\n1.0001\n3\n5";
+        String excepted = "1.234e+07\n7.234243E-02";
+
+        //when
+        System.out.println(excepted);
+        System.out.println();
+
+        //then
+        SelectingNumbers.selectionNumbersInExponentialNotationFromText(text);
+    }
+}


### PR DESCRIPTION
Z poniższego tekstu:
342
5.34
756
1.234e+07
7.234243E-02
6.09
3457
87
1.0001
3
5
Wybierz za pomocą wyrażenia regularnego:
liczby całkowite, na przykład 87,3.
liczby zmiennoprzecinkowe, na przykład: 6.09, 5.34
liczby w notacji naukowej, na przykład: 1.234e+07